### PR TITLE
db schema for metaDocs Table

### DIFF
--- a/db_schema/db_migration.sql
+++ b/db_schema/db_migration.sql
@@ -87,8 +87,9 @@ CREATE TABLE
 		id UUID DEFAULT gen_random_uuid () PRIMARY KEY,
 		tasks_id UUID,
 		created_by UUID,
-		created_time date,
-		doc_url VARCHAR(20)
+		doc_name VARCHAR(20),
+		doc_url VARCHAR(20),
+		created_time date
 	);
 ALTER TABLE metadocs_table
 ADD CONSTRAINT fk_metadocs_tasks_id FOREIGN KEY (tasks_id) REFERENCES tasks_table (id),

--- a/db_schema/db_migration.sql
+++ b/db_schema/db_migration.sql
@@ -87,10 +87,15 @@ CREATE TABLE
 		id UUID DEFAULT gen_random_uuid () PRIMARY KEY,
 		tasks_id UUID,
 		created_by UUID,
-		doc_name VARCHAR(20),
-		doc_url VARCHAR(20),
-		created_time timestamp
+		created_time date,
+		doc_url VARCHAR(20)
 	);
 ALTER TABLE metadocs_table
 ADD CONSTRAINT fk_metadocs_tasks_id FOREIGN KEY (tasks_id) REFERENCES tasks_table (id),
 ADD CONSTRAINT fk_metadocs_created_by FOREIGN KEY (created_by) REFERENCES resources_table (id);
+
+ALTER TABLE metadocs_table
+ADD COLUMN doc_name VARCHAR(20);
+
+ALTER TABLE metadocs_table
+ALTER COLUMN created_time TYPE timestamp;

--- a/db_schema/db_migration.sql
+++ b/db_schema/db_migration.sql
@@ -89,7 +89,7 @@ CREATE TABLE
 		created_by UUID,
 		doc_name VARCHAR(20),
 		doc_url VARCHAR(20),
-		created_time date
+		created_time timestamp
 	);
 ALTER TABLE metadocs_table
 ADD CONSTRAINT fk_metadocs_tasks_id FOREIGN KEY (tasks_id) REFERENCES tasks_table (id),

--- a/db_schema/db_migration.sql
+++ b/db_schema/db_migration.sql
@@ -81,3 +81,15 @@ references resources_table(id);
 
 alter table tasks_table  
 add column comments JSONB;
+
+CREATE TABLE
+	metadocs_table (
+		id UUID DEFAULT gen_random_uuid () PRIMARY KEY,
+		tasks_id UUID,
+		created_by UUID,
+		created_time date,
+		doc_url VARCHAR(20)
+	);
+ALTER TABLE metadocs_table
+ADD CONSTRAINT fk_metadocs_tasks_id FOREIGN KEY (tasks_id) REFERENCES tasks_table (id),
+ADD CONSTRAINT fk_metadocs_created_by FOREIGN KEY (created_by) REFERENCES resources_table (id);


### PR DESCRIPTION
### db schema for metaDocs Table
**Description:** The metadocs_table has columns for ID, task ID, creator ID, document Name, document URL, and creation time with foreign key constraints linking task and creator IDs to their respective tables.