### PR TITLE
feat:removed not null constraints from address table

### DIFF
--- a/db_schema/db_migration.sql
+++ b/db_schema/db_migration.sql
@@ -299,3 +299,11 @@ drop column password;
 
 alter table document
 add constraint fk_document_emp_id foreign KEY(emp_id) references employee(id);
+
+ALTER TABLE address
+ALTER COLUMN address_line_1 DROP NOT NULL,
+ALTER COLUMN landmark DROP NOT NULL,
+ALTER COLUMN country DROP NOT NULL,
+ALTER COLUMN state DROP NOT NULL,
+ALTER COLUMN city DROP NOT NULL,
+ALTER COLUMN zipcode DROP NOT NULL;


### PR DESCRIPTION

This PR removes the NOT NULL constraints from several columns in the `address` table. The constraints were removed as part of a requirement to allow flexibility in data entry and to accommodate cases where certain address details might not be available.

Changes Made:
- Removed NOT NULL constraint from address_line_1, landmark, country, state, city, and zipcode columns in the `address` table.
```sql

ALTER TABLE address
ALTER COLUMN address_line_1 DROP NOT NULL,
ALTER COLUMN landmark DROP NOT NULL,
ALTER COLUMN country DROP NOT NULL,
ALTER COLUMN state DROP NOT NULL,
ALTER COLUMN city DROP NOT NULL,
ALTER COLUMN zipcode DROP NOT NULL;
```

Reason for Changes:
- Address information may not always be complete, and enforcing NOT NULL constraints could lead to data entry issues.
- Flexibility is required to handle various address formats and scenarios.